### PR TITLE
Ignore swoole exit exception

### DIFF
--- a/co-phpunit
+++ b/co-phpunit
@@ -57,9 +57,13 @@
 
     require PHPUNIT_COMPOSER_INSTALL;
 
-    $code = PHPUnit\TextUI\Command::main(false);
-    if ($code > 0) {
-        exit($code);
+    try {
+        $code = PHPUnit\TextUI\Command::main(false);
+        if ($code > 0) {
+            exit($code);
+        }
+    } catch (\Swoole\ExitException $e) {
+        // ignore exit exception
     }
 
     swoole_event_exit();


### PR DESCRIPTION
忽略Swoole扩展抛出的退出异常

```bash
$ php co-phpunit --version
PHPUnit 7.5.16 by Sebastian Bergmann and contributors.

PHP Fatal error:  Uncaught Swoole\ExitException: swoole exit in /Users/iFree/data/projects/my/php/testing/vendor/phpunit/phpunit/src/TextUI/Command.php:662
Stack trace:
#0 /Users/iFree/data/projects/my/php/testing/vendor/phpunit/phpunit/src/TextUI/Command.php(173): PHPUnit\TextUI\Command->handleArguments(Array)
#1 /Users/iFree/data/projects/my/php/testing/vendor/phpunit/phpunit/src/TextUI/Command.php(162): PHPUnit\TextUI\Command->run(Array, false)
#2 /Users/iFree/data/projects/my/php/testing/co-phpunit(60): PHPUnit\TextUI\Command::main(false)
#3 {main}
  thrown in /Users/iFree/data/projects/my/php/testing/vendor/phpunit/phpunit/src/TextUI/Command.php on line 662
```

我本地Swoole扩展版本4.4.5，没有测试过低版本下会不会抛这个异常，虽然这个并不影响功能的正常测试，但是打印到命令行一个是会扰乱测试信息，另一个是强迫症看着不舒服😹（主要原因）

希望能合并到版本库 @huangzhhui @limingxinleo 